### PR TITLE
Add support for R_ARC_NONE relocations.

### DIFF
--- a/ldso/ldso/arc/elfinterp.c
+++ b/ldso/ldso/arc/elfinterp.c
@@ -144,6 +144,8 @@ _dl_do_reloc(struct elf_resolve *tpnt, struct r_scope_elem *scope,
 #endif
 
 	switch (reloc_type) {
+	case R_ARC_NONE:
+		break;
 	case R_ARC_32:
 		*reloc_addr += symbol_addr + rpnt->r_addend;
 		break;
@@ -202,6 +204,8 @@ _dl_do_lazy_reloc(struct elf_resolve *tpnt, struct r_scope_elem *scope,
 #endif
 
 	switch (reloc_type) {
+	case R_ARC_NONE:
+		break;
 	case R_ARC_JMP_SLOT:
 		*reloc_addr += tpnt->loadaddr;
 		break;


### PR DESCRIPTION
The R_ARC_NONE relocation is generated when --gc-sections removes some sections.  This is completely normal, and we can see that all other targets (based on a random sampling) have support for R_*_NONE relocations (named for each target).

Handling R_ARC_NONE involves doing nothing with it, which is nice and easy.
