### PR TITLE
ARC: Switch to r25 for TP_REG on ARC HS.

### DIFF
--- a/libpthread/nptl/sysdeps/arc/tls.h
+++ b/libpthread/nptl/sysdeps/arc/tls.h
@@ -39,11 +39,7 @@ typedef struct
 #else /* __ASSEMBLER__ */
 # include <tcb-offsets.h>
 
-#ifdef __A7__
 #define __ARC_TP_REG	r25
-#elif defined(__HS__)
-#define __ARC_TP_REG	r30
-#endif
 
 .macro THREAD_SELF reg
 	# struct pthread is just ahead of TCB


### PR DESCRIPTION
In order to speed up support for TLS on all targets, having a single unified TLS register will make things easier.

This was discussed here: https://github.com/foss-for-synopsys-dwc-arc-processors/uClibc/commit/d56c240dfa32c0cf323d8b447bf9597ce9d339d2#commitcomment-9672784 I've not included the config changes as I don't wish to enable any tls features by default within the build just yet.  Changing the tls register should make no difference unless tls is being built and tested.
