### PR TITLE
test/silly: Extend include path.

### DIFF
--- a/libc/stdlib/_atexit.c
+++ b/libc/stdlib/_atexit.c
@@ -97,7 +97,7 @@ extern int __cxa_atexit(cxaefuncp, void *arg, void *dso_handle);
 
 /* remove old_atexit after 0.9.29 */
 #if defined(L_atexit) || defined(L_old_atexit)
-extern void *__dso_handle __attribute__ ((__weak__)) __attribute__((visibility ("hidden")));;
+extern void *__dso_handle __attribute__ ((__weak__));
 
 /*
  * register a function to be called at normal program termination

--- a/libc/stdlib/_atexit.c
+++ b/libc/stdlib/_atexit.c
@@ -97,7 +97,7 @@ extern int __cxa_atexit(cxaefuncp, void *arg, void *dso_handle);
 
 /* remove old_atexit after 0.9.29 */
 #if defined(L_atexit) || defined(L_old_atexit)
-extern void *__dso_handle __attribute__ ((__weak__));
+extern void *__dso_handle __attribute__ ((__weak__)) __attribute__((visibility ("hidden")));;
 
 /*
  * register a function to be called at normal program termination

--- a/test/silly/Makefile.in
+++ b/test/silly/Makefile.in
@@ -6,3 +6,7 @@ RET_tiny  := 42
 
 # missing internal headers, disable these
 GLIBC_TESTS_DISABLED := tst-atomic_glibc tst-atomic-long_glibc
+
+EXTRA_CFLAGS := -I$(top_srcdir)libc/sysdeps/linux/$(TARGET_ARCH) \
+	-I$(top_srcdir)libc/sysdeps/linux \
+	-I$(top_builddir)include


### PR DESCRIPTION
When attempting to build this test using buildroot then compilation errors are seen due to being unable to find header files.

Taking inspiration from the nptl tests, I have extended the CFLAGS variable to add the required include paths.  The tests can now be built using buildroot.
