### PR TITLE
arc: fix signal handler restorer

### DIFF
--- a/libc/sysdeps/linux/arc/sigrestorer.S
+++ b/libc/sysdeps/linux/arc/sigrestorer.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Synopsys, Inc. (www.synopsys.com)
+ * Copyright (C) 2017, 2021 Synopsys, Inc. (www.synopsys.com)
  *
  * Licensed under the LGPL v2.1 or later, see the file COPYING.LIB in this tarball.
  */
@@ -22,4 +22,5 @@
 __default_rt_sa_restorer:
 	mov r8, __NR_rt_sigreturn
 	ARC_TRAP_INSN
+	j_s     [blink]
 


### PR DESCRIPTION
When MD_FALLBACK_FRAME_STATE_FOR handler in libgcc unwind code checks
the second instruction opcode in __default_rt_sa_restorer function,
it expects to see the following values for ARC cores:
- 0x7ee0781e for ARCv2 LE
- 0x003f226f for ARC700 LE

ARC700 value correspond to trap0 instruction. ARCv2 value corresponds
to the following code:
        traps_0
        j_s     [blink]

However, unlike glibc, uClibc implementation of __default_rt_sa_restorer
for ARC does not have that jump. Hence libgcc unwind code is not able
to recognize signal frame correctly on ARCv2 and completes too early.

This change fixes libgcc unwinding over signal frame on ARCv2 adding
missing jump to __default_rt_sa_restorer.

Signed-off-by: Sergey Matyukevich <sergey.matyukevich@synopsys.com>