### PR TITLE
 arc: add support for ARCv3 32-bit processors

### DIFF
--- a/include/elf.h
+++ b/include/elf.h
@@ -273,6 +273,8 @@ typedef struct
 #define EM_ARCV2	195		/* Synopsys ARCv2 Cores */
 #define EM_RISCV        243     	/* RISC-V */
 #define EM_CSKY		252		/* C-SKY Cores */
+#define EM_ARCV3        253		/* Synopsys ARCv3 64-bit Cores */
+#define EM_ARCV3_32     255		/* Synopsys ARCv3 32-bit Cores */
 #define EM_KVX		256		/* Kalray VLIW core of the MPPA processor family */
 
 /* NEXT FREE NUMBER: Increment this after adding your official arch number */

--- a/include/elf.h
+++ b/include/elf.h
@@ -270,7 +270,7 @@ typedef struct
 #define EM_METAG	174		/* Imagination Technologies Meta */
 #define EM_AARCH64	183		/* ARM AARCH64 */
 #define EM_MICROBLAZE	189		/* Xilinx Microblaze */
-#define EM_ARCV2	195		/* ARCv2 Cores */
+#define EM_ARCV2	195		/* Synopsys ARCv2 Cores */
 #define EM_RISCV        243     	/* RISC-V */
 #define EM_CSKY		252		/* C-SKY Cores */
 #define EM_KVX		256		/* Kalray VLIW core of the MPPA processor family */

--- a/ldso/ldso/Makefile.in
+++ b/ldso/ldso/Makefile.in
@@ -38,7 +38,8 @@ CFLAGS-ldso.c	+= -DLDSO_MULTILIB_DIR=\"$(MULTILIB_DIR)\"
 endif
 
 ifeq ($(TARGET_ARCH),arc)
-CFLAGS-ldso.c += -mno-long-calls
+$(eval $(call check-gcc-var,-mno-long-calls))
+CFLAGS-ldso.c += $(CFLAGS_-mno-long-calls)
 endif
 
 LDFLAGS-$(UCLIBC_FORMAT_DSBT_ELF)-$(UCLIBC_LDSO_NAME).so := -Wl,--dsbt-index=1

--- a/ldso/ldso/arc/dl-sysdep.h
+++ b/ldso/ldso/arc/dl-sysdep.h
@@ -75,6 +75,9 @@ do {									\
 #elif defined(__HS__)
 #define MAGIC1 EM_ARCV2
 #define ELF_TARGET "ARCv2"	/* For error messages */
+#elif defined(__ARC64_ARCH32__)
+#define MAGIC1 EM_ARCV3_32
+#define ELF_TARGET "ARCv3_32"	/* For error messages */
 #endif
 
 #undef  MAGIC2

--- a/ldso/ldso/arc/resolve.S
+++ b/ldso/ldso/arc/resolve.S
@@ -12,30 +12,47 @@
 ; 	r10-r12 are already clobbered by PLTn, PLT0 thus neednot be saved
 
 .macro	SAVE_CALLER_SAVED
+#ifdef __ARC64_ARCH32__
+	push	r0
+	push	r1
+	push	r2
+	push	r3
+#else
 	push_s	r0
 	push_s	r1
 	push_s	r2
 	push_s	r3
-	st.a	r4, [sp, -4]
-	st.a	r5, [sp, -4]
-	st.a	r6, [sp, -4]
-	st.a	r7, [sp, -4]
-	st.a	r8, [sp, -4]
-	st.a	r9, [sp, -4]
+#endif
+	push	r4
+	push	r5
+	push	r6
+	push	r7
+	push	r8
+	push	r9
+#ifdef __ARC64_ARCH32__
+	push	blink
+#else
 	push_s	blink
+#endif
 .endm
 
 .macro RESTORE_CALLER_SAVED_BUT_R0
-	ld.ab	blink,[sp, 4]
-	ld.ab	r9, [sp, 4]
-	ld.ab	r8, [sp, 4]
-	ld.ab	r7, [sp, 4]
-	ld.ab	r6, [sp, 4]
-	ld.ab	r5, [sp, 4]
-	ld.ab	r4, [sp, 4]
-	pop_s   r3
-	pop_s   r2
-	pop_s   r1
+	pop	blink
+	pop	r9
+	pop	r8
+	pop	r7
+	pop	r6
+	pop	r5
+	pop	r4
+#ifdef __ARC64_ARCH32__
+	pop	r3
+	pop	r2
+	pop	r1
+#else
+	pop_s	r3
+	pop_s	r2
+	pop_s	r1
+#endif
 .endm
 
 ; Upon entry, PLTn, which led us here, sets up the following regs
@@ -53,5 +70,9 @@ ENTRY(_dl_linux_resolve)
 
 	RESTORE_CALLER_SAVED_BUT_R0
 	j_s.d   [r0]    ; r0 has resolved function addr
-	pop_s   r0      ; restore first arg to resolved call
+#ifdef __ARC64_ARCH32__
+	pop	r0      ; restore first arg to resolved call
+#else
+	pop_s	r0      ; restore first arg to resolved call
+#endif
 END(_dl_linux_resolve)

--- a/ldso/ldso/arc/resolve.S
+++ b/ldso/ldso/arc/resolve.S
@@ -4,6 +4,7 @@
  * Licensed under the LGPL v2.1 or later, see the file COPYING.LIB in this tarball.
  */
 
+#include <asm.h>
 #include <sysdep.h>
 #include <sys/syscall.h>
 
@@ -12,47 +13,30 @@
 ; 	r10-r12 are already clobbered by PLTn, PLT0 thus neednot be saved
 
 .macro	SAVE_CALLER_SAVED
-#ifdef __ARC64_ARCH32__
-	push	r0
-	push	r1
-	push	r2
-	push	r3
-#else
-	push_s	r0
-	push_s	r1
-	push_s	r2
-	push_s	r3
-#endif
-	push	r4
-	push	r5
-	push	r6
-	push	r7
-	push	r8
-	push	r9
-#ifdef __ARC64_ARCH32__
-	push	blink
-#else
-	push_s	blink
-#endif
+	PUSHR_S	r0
+	PUSHR_S	r1
+	PUSHR_S	r2
+	PUSHR_S	r3
+	PUSHR	r4
+	PUSHR	r5
+	PUSHR	r6
+	PUSHR	r7
+	PUSHR	r8
+	PUSHR	r9
+	PUSHR_S	blink
 .endm
 
 .macro RESTORE_CALLER_SAVED_BUT_R0
-	pop	blink
-	pop	r9
-	pop	r8
-	pop	r7
-	pop	r6
-	pop	r5
-	pop	r4
-#ifdef __ARC64_ARCH32__
-	pop	r3
-	pop	r2
-	pop	r1
-#else
-	pop_s	r3
-	pop_s	r2
-	pop_s	r1
-#endif
+	POPR	blink
+	POPR	r9
+	POPR	r8
+	POPR	r7
+	POPR	r6
+	POPR	r5
+	POPR	r4
+	POPR_S	r3
+	POPR_S	r2
+	POPR_S	r1
 .endm
 
 ; Upon entry, PLTn, which led us here, sets up the following regs
@@ -70,9 +54,5 @@ ENTRY(_dl_linux_resolve)
 
 	RESTORE_CALLER_SAVED_BUT_R0
 	j_s.d   [r0]    ; r0 has resolved function addr
-#ifdef __ARC64_ARCH32__
-	pop	r0      ; restore first arg to resolved call
-#else
-	pop_s	r0      ; restore first arg to resolved call
-#endif
+	POPR_S	r0      ; restore first arg to resolved call
 END(_dl_linux_resolve)

--- a/libc/sysdeps/linux/arc/asm.h
+++ b/libc/sysdeps/linux/arc/asm.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2022, Synopsys, Inc. (www.synopsys.com)
+ *
+ * Licensed under the LGPL v2.1 or later, see the file COPYING.LIB in this tarball.
+ */
+
+#ifndef _ARC_ASM_H
+#define _ARC_ASM_H
+
+#if defined (__ARC64_ARCH32__)
+
+.macro PUSHR   r
+  push	\r
+.endm
+
+.macro PUSHR_S   r
+  push	\r
+.endm
+
+.macro POPR r
+  pop	\r
+.endm
+
+.macro POPR_S r
+  pop	\r
+.endm
+
+.macro ADDR_S r1, r2, v
+  add	\r1, \r2, \v
+.endm
+
+#elif defined (__ARC64_ARCH64__)
+
+# error ARCv3 64-bit is not supported by uClibc-ng
+
+#else /* ARCHS || ARC700 */
+
+.macro PUSHR   r
+  push	\r
+.endm
+
+.macro PUSHR_S   r
+  push_s	\r
+.endm
+
+.macro POPR   r
+  pop	\r
+.endm
+
+.macro POPR_S   r
+  pop_s	\r
+.endm
+
+.macro ADDR_S r1, r2, v
+  add_s	\r1, \r2, \v
+.endm
+
+#endif
+
+#endif /* _ARC_ASM_H  */

--- a/libc/sysdeps/linux/arc/bits/syscalls.h
+++ b/libc/sysdeps/linux/arc/bits/syscalls.h
@@ -100,7 +100,7 @@ extern long __syscall_error (int);
 
 #ifdef __A7__
 #define ARC_TRAP_INSN	"trap0		\n\t"
-#elif defined(__HS__)
+#else
 #define ARC_TRAP_INSN	"trap_s 0	\n\t"
 #endif
 
@@ -182,7 +182,7 @@ extern long __syscall_error (int);
 
 #ifdef __A7__
 #define ARC_TRAP_INSN	trap0
-#elif defined(__HS__)
+#else
 #define ARC_TRAP_INSN	trap_s 0
 #endif
 

--- a/libc/sysdeps/linux/arc/crt1.S
+++ b/libc/sysdeps/linux/arc/crt1.S
@@ -4,6 +4,7 @@
  * Licensed under the LGPL v2.1 or later, see the file COPYING.LIB in this tarball.
  */
 
+#include <asm.h>
 #include <features.h>
 
 .text
@@ -40,11 +41,7 @@ __start:
 	ld_s	r1, [sp]	; argc
 
 	mov_s	r5, r0		; rltd_fini
-#ifdef __ARC64_ARCH32__
-	add	r2, sp, 4	; argv
-#else
-	add_s	r2, sp, 4	; argv
-#endif
+	ADDR_S	r2, sp, 4	; argv
 #ifdef L_Scrt1
 	ld	r0, [pcl, @main@gotpc]
 	ld	r3, [pcl, @_init@gotpc]

--- a/libc/sysdeps/linux/arc/crt1.S
+++ b/libc/sysdeps/linux/arc/crt1.S
@@ -40,7 +40,11 @@ __start:
 	ld_s	r1, [sp]	; argc
 
 	mov_s	r5, r0		; rltd_fini
+#ifdef __ARC64_ARCH32__
+	add	r2, sp, 4	; argv
+#else
 	add_s	r2, sp, 4	; argv
+#endif
 #ifdef L_Scrt1
 	ld	r0, [pcl, @main@gotpc]
 	ld	r3, [pcl, @_init@gotpc]

--- a/utils/ldd.c
+++ b/utils/ldd.c
@@ -30,7 +30,7 @@
 #endif
 
 #if defined(__arc__)
-#define MATCH_MACHINE(x) (x == EM_ARCOMPACT)
+#define MATCH_MACHINE(x) (x == EM_ARCOMPACT || x == EM_ARCV2)
 #define ELFCLASSM      ELFCLASS32
 #endif
 

--- a/utils/ldd.c
+++ b/utils/ldd.c
@@ -34,6 +34,11 @@
 #define ELFCLASSM      ELFCLASS32
 #endif
 
+#if defined(__ARC64_ARCH32__)
+#define MATCH_MACHINE(x) (x == EM_ARCV3_32)
+#define ELFCLASSM      ELFCLASS32
+#endif
+
 #if defined(__arm__) || defined(__thumb__)
 #define MATCH_MACHINE(x) (x == EM_ARM)
 #define ELFCLASSM	ELFCLASS32


### PR DESCRIPTION
### Summary
This PR adds support for 32-bit ARCv3 HS5x processors.

Known limitations:
1. TODO: optimized HS5x assembly for str/mem operations. At the moment generic str/mem operations are used.
2. What else I could miss ?

### Test results
Accompanying PR for uclibc-ng-test: [arc: tls macros for hs5x](https://github.com/foss-for-synopsys-dwc-arc-processors/uclibc-ng-test/pull/1).

Here is a summary of uclibc-ng test suite results on nSIM:

- 409 tests PASSED
- 9 tests FAILED
  - tst-cancel13, tst-cancel18, tst-cancelx18, tst-cpuclock1, tst-cpuclock2, tst-tls1, tst-tls2, tst-ethers-line, tst-ethers
- 16 tests SKIPPED
  -  argp-ex1, argp-ex2, argp-ex3, argp-ex4, argp-test, bug-argp1, tst-argp1, tst-argp2, tst-iconv1, tst-iconv2, tst-iconv3, tst-iconv4, tst-iconv5, tst-iconv6, tst-regexloc

These results are almost the same as up-to-date uclibc-ng tests results for ARCHS on nSIM. The only exceptions are the following two additional failed tests for HS5x: tst-cpuclock1, tst-cpuclock2.

### Fix for gcc
At the moment arc64 gcc branch does not include the fix for signal handler unwind. For arc version of that fix see the followign commit by @claziss:  [arc: Add DWARF2 alternate CFA column](https://github.com/foss-for-synopsys-dwc-arc-processors/gcc/commit/6427669a55d1fe364be7cffbaf67cb0a707a1cfb). 

So, in order to get reasonable results for tst-cancel pthread tests, the following workaround has been used:
```
diff --git a/libgcc/config/arc64/linux-unwind.h b/libgcc/config/arc64/linux-unwind.h
index 46ca6aa367b..14ba8828b69 100644
--- a/libgcc/config/arc64/linux-unwind.h
+++ b/libgcc/config/arc64/linux-unwind.h
@@ -129,11 +129,12 @@ arc_fallback_frame_state (struct _Unwind_Context *context,
     }

   /* Special case for handling blink: blink <--> ret.  */
-  fs->regs.reg[reg_offset_map[REG_BLINK]].how = REG_SAVED_VAL_OFFSET;
-  fs->regs.reg[reg_offset_map[REG_BLINK]].loc.offset
+  fs->signal_frame = 1;
+  fs->regs.reg[29].how = REG_SAVED_VAL_OFFSET;
+  fs->regs.reg[29].loc.offset
     = ((_Unwind_Ptr)(regs[REG_RET])) - new_cfa;

-  fs->retaddr_column = reg_offset_map[REG_BLINK];
+  fs->retaddr_column = 29;

   return _URC_NO_REASON;
 }
```
