### PR TITLE
Add acq/rel variants of cmpxchg/xchng with memory barriers after/before exchange

### DIFF
--- a/libc/sysdeps/linux/arc/bits/atomic.h
+++ b/libc/sysdeps/linux/arc/bits/atomic.h
@@ -26,8 +26,10 @@ void __arc_link_error (void);
 
 #ifdef __A7__
 #define atomic_full_barrier() __asm__ __volatile__("": : :"memory")
+#define ARC_BARRIER_INSTR 	""
 #else
 #define atomic_full_barrier() __asm__ __volatile__("dmb 3": : :"memory")
+#define ARC_BARRIER_INSTR 	"dmb 3"
 #endif
 
 /* Atomic compare and exchange. */
@@ -38,30 +40,56 @@ void __arc_link_error (void);
 #define __arch_compare_and_exchange_val_16_acq(mem, newval, oldval) \
   ({ __arc_link_error (); oldval; })
 
-#define __arch_compare_and_exchange_val_64_acq(mem, newval, oldval)	\
+#define __arch_compare_and_exchange_val_64_acq(mem, newval, oldval) \
+  ({ __arc_link_error (); oldval; })
+
+#define __arch_compare_and_exchange_val_8_rel(mem, newval, oldval) \
+  ({ __arc_link_error (); oldval; })
+
+#define __arch_compare_and_exchange_val_16_rel(mem, newval, oldval) \
+  ({ __arc_link_error (); oldval; })
+
+#define __arch_compare_and_exchange_val_64_rel(mem, newval, oldval) \
   ({ __arc_link_error (); oldval; })
 
 #ifdef __CONFIG_ARC_HAS_ATOMICS__
 
-#define __arch_compare_and_exchange_val_32_acq(mem, newval, oldval)     \
+#define USE_ATOMIC_COMPILER_BUILTINS 1
+
+#define __arch_compare_and_exchange_val_32_acq(mem, newval, oldval)	\
   ({									\
-	__typeof(oldval) prev;						\
-									\
-	__asm__ __volatile__(						\
-	"1:	llock   %0, [%1]	\n"				\
-	"	brne    %0, %2, 2f	\n"				\
-	"	scond   %3, [%1]	\n"				\
-	"	bnz     1b		\n"				\
-	"2:				\n"				\
-	: "=&r"(prev)							\
-	: "r"(mem), "ir"(oldval),					\
-	  "r"(newval) /* can't be "ir". scond can't take limm for "b" */\
-	: "cc", "memory");						\
-									\
-	prev;								\
+    __typeof(*mem) __oldval = (oldval);					\
+    __atomic_compare_exchange_n(mem, (void *) &__oldval, newval, 0,	\
+                                 __ATOMIC_ACQUIRE, __ATOMIC_RELAXED);	\
+    __oldval;								\
   })
 
-#else
+#define __arch_compare_and_exchange_val_32_rel(mem, newval, oldval)	\
+  ({									\
+    __typeof(*mem) __oldval = (oldval);					\
+    __atomic_compare_exchange_n(mem, (void *) &__oldval, newval, 0,	\
+                                 __ATOMIC_RELEASE, __ATOMIC_RELAXED);	\
+    __oldval;								\
+  })
+
+/* Compare and exchange with "acquire" semantics, ie barrier after */
+#define atomic_compare_and_exchange_val_acq(mem, new, old)		\
+  __atomic_val_bysize(__arch_compare_and_exchange_val, acq,		\
+                       mem, new, old)
+
+/* Compare and exchange with "release" semantics, ie barrier before */
+#define atomic_compare_and_exchange_val_rel(mem, new, old)		\
+  __atomic_val_bysize(__arch_compare_and_exchange_val, rel,		\
+                       mem, new, old)
+/* Explicitly define here to use release semantics*/
+#define atomic_compare_and_exchange_bool_rel(mem, newval, oldval) \
+  ({									\
+     __typeof (oldval) __atg3_old = (oldval);				\
+     atomic_compare_and_exchange_val_rel (mem, newval, __atg3_old)	\
+       != __atg3_old;							\
+  })
+
+#else /* !__CONFIG_ARC_HAS_ATOMICS__ */
 
 #ifndef __NR_arc_usr_cmpxchg
 #error "__NR_arc_usr_cmpxchg missing: Please upgrade to kernel 4.9+ headers"
@@ -101,6 +129,21 @@ void __arc_link_error (void);
 	__typeof__(*(mem)) val = newval;				\
 									\
 	__asm__ __volatile__(						\
+	"ex %0, [%1]\n"							\
+	ARC_BARRIER_INSTR						\
+	: "+r" (val)							\
+	: "r" (mem)							\
+	: "memory" );							\
+									\
+	val;								\
+  })
+
+#define __arch_exchange_32_rel(mem, newval)				\
+  ({									\
+	__typeof__(*(mem)) val = newval;				\
+									\
+	__asm__ __volatile__(						\
+	ARC_BARRIER_INSTR"\n"						\
 	"ex %0, [%1]"							\
 	: "+r" (val)							\
 	: "r" (mem)							\
@@ -115,3 +158,11 @@ void __arc_link_error (void);
 		abort();						\
 	__arch_exchange_32_acq(mem, newval);				\
   })
+
+#define atomic_exchange_rel(mem, newval)				\
+  ({									\
+	if (sizeof(*(mem)) != 4)					\
+		abort();						\
+	__arch_exchange_32_rel(mem, newval);				\
+  })
+


### PR DESCRIPTION
Add acquire/release variants for atomic functions cmpxchg/xchg and provide memory barrier after/before exchange.                                                                                                                                                                                                             For cmpxchg use builtins provided by the compiler. The compiler implements acq/rel semantics and puts memory barriers after/before exchange code. For xchg functions add memory barrier explicitly.
These barriers are required to keep memory consistence in SMP ARCv3 CPUs.

This branch is a copy of [pvk-atomic-acq-rel](https://github.com/foss-for-synopsys-dwc-arc-processors/uClibc/tree/pvk-atomic-acq-rel) used in verification. This branch has been created to gather separate commits to one and merge to the 2023.03 branch. 
