### PR TITLE
arc: remove forward read in ARCHS asm strcmp code

### DIFF
--- a/libc/string/arc/strcmp.S
+++ b/libc/string/arc/strcmp.S
@@ -103,23 +103,21 @@ ENTRY(strcmp)
 	brne	r2, 0, @.Lcharloop
 
 ;;; s1 and s2 are word aligned
-	ld.ab	r2, [r0, 4]
 
 	mov_s	r12, 0x01010101
 	ror	r11, r12
 	.align  4
 .LwordLoop:
+	ld.ab	r2, [r0, 4]
+	sub	r4, r2, r12
 	ld.ab	r3, [r1, 4]
 	;; Detect NULL char in str1
-	sub	r4, r2, r12
-	ld.ab	r5, [r0, 4]
 	bic	r4, r4, r2
 	and	r4, r4, r11
 	brne.d.nt	r4, 0, .LfoundNULL
 	;; Check if the read locations are the same
 	cmp	r2, r3
-	beq.d	.LwordLoop
-	mov.eq	r2, r5
+	beq	.LwordLoop
 
 	;; A match is found, spot it out
 #ifdef __LITTLE_ENDIAN__


### PR DESCRIPTION
Remove the read-ahead in the per-word compare loop as it can cause a segmentation fault in certain circumstances (string at the end of the mapped page). For baremetal this relaxed approach is suitable but in Linux with MMU we should be more restrictive.

No regressions in uclibc-ng-tests:
```
Total skipped: 7
Total failed: 4
Total passed: 469
```